### PR TITLE
system/netd: Squash of app fw restriction commits

### DIFF
--- a/server/BandwidthController.cpp
+++ b/server/BandwidthController.cpp
@@ -319,6 +319,8 @@ int BandwidthController::enableBandwidthControl() {
     mGlobalAlertBytes = 0;
     mSharedQuotaBytes = mSharedAlertBytes = 0;
 
+    mRestrictAppsOnInterface.clear();
+
     flushCleanTables(false);
 
     std::string commands = Join(getBasicAccountingCommands(mBpfSupported), '\n');
@@ -390,6 +392,62 @@ int BandwidthController::addNiceApps(const std::vector<std::string>& appStrUid) 
 
 int BandwidthController::removeNiceApps(const std::vector<std::string>& appStrUid) {
     return manipulateSpecialApps(appStrUid, NICE_CHAIN, IptJumpReturn, IptOpDelete);
+}
+
+int BandwidthController::addRestrictAppsOnInterface(const std::string& usecase,
+                                                    const std::string& iface,
+                                                    const std::vector<std::string>& appStrUid) {
+    return manipulateRestrictAppsInOut(usecase, iface, appStrUid, IptOpInsert);
+}
+
+int BandwidthController::removeRestrictAppsOnInterface(const std::string& usecase,
+                                                    const std::string& iface,
+                                                    const std::vector<std::string>& appStrUid) {
+    return manipulateRestrictAppsInOut(usecase, iface, appStrUid, IptOpDelete);
+}
+
+int BandwidthController::manipulateRestrictAppsInOut(const std::string& usecase,
+                                                     const std::string& iface,
+                                                     const std::vector<std::string>& appStrUid,
+                                                     IptOp op) {
+    int ret;
+    std::string chain;
+    /* Keep separate per app uid vectors for each usecase (vpn, wlan etc) */
+    std::vector<int>& restrictAppUids = mRestrictAppsOnInterface[usecase];
+
+    chain = StringPrintf("INPUT -i %s", iface.c_str());
+    ret = manipulateRestrictApps(appStrUid, chain, restrictAppUids, op);
+    if (ret != 0) {
+        return ret;
+    }
+    chain = StringPrintf("OUTPUT -o %s", iface.c_str());
+    ret = manipulateRestrictApps(appStrUid, chain, restrictAppUids, op);
+    return ret;
+}
+
+int BandwidthController::manipulateRestrictApps(const std::vector<std::string>& appStrUids,
+                                                const std::string& chain,
+                                                std::vector<int /*appUid*/>& restrictAppUids,
+                                                IptOp op) {
+    for (const auto& appStrUid : appStrUids) {
+        int uid = std::stoi(appStrUid, nullptr, 0);
+        auto it = std::find(restrictAppUids.begin(), restrictAppUids.end(), uid);
+        bool found = (it != restrictAppUids.end());
+        if (op == IptOpDelete) {
+            if (!found) {
+                ALOGE("No such appUid %d to remove", uid);
+                return -1;
+            }
+            restrictAppUids.erase(it);
+        } else {
+            if (found && android::base::StartsWith(chain, "INPUT")) {
+                ALOGE("appUid %d exists already", uid);
+                return -1;
+            }
+            restrictAppUids.push_back(uid);
+        }
+    }
+    return manipulateSpecialApps(appStrUids, chain, IptJumpReject, op);
 }
 
 int BandwidthController::manipulateSpecialApps(const std::vector<std::string>& appStrUids,

--- a/server/BandwidthController.h
+++ b/server/BandwidthController.h
@@ -57,6 +57,11 @@ public:
     int addNiceApps(const std::vector<std::string>& appStrUid);
     int removeNiceApps(const std::vector<std::string>& appStrUid);
 
+    int addRestrictAppsOnInterface(const std::string& usecase, const std::string& iface,
+                                   const std::vector<std::string>& appStrUid);
+    int removeRestrictAppsOnInterface(const std::string& usecase, const std::string& iface,
+                                      const std::vector<std::string>& appStrUid);
+
     int setGlobalAlert(int64_t bytes);
     int removeGlobalAlert();
     int setGlobalAlertInForwardChain();
@@ -95,6 +100,12 @@ public:
 #endif
 
     std::string makeDataSaverCommand(IptablesTarget target, bool enable);
+
+    int manipulateRestrictAppsInOut(const std::string& usecase, const std::string& iface,
+                                    const std::vector<std::string>& appStrUids, IptOp appOp);
+
+    int manipulateRestrictApps(const std::vector<std::string>& appStrUids, const std::string& chain,
+                               std::vector<int /*appUid*/>& restrictAppUids, IptOp appOp);
 
     int manipulateSpecialApps(const std::vector<std::string>& appStrUids, const std::string& chain,
                               IptJumpOp jumpHandling, IptOp appOp);
@@ -140,6 +151,8 @@ public:
 
     std::map<std::string, QuotaInfo> mQuotaIfaces;
     std::set<std::string> mSharedQuotaIfaces;
+
+    std::map<std::string /* interface name*/, std::vector<int /*appUid*/>> mRestrictAppsOnInterface;
 };
 
 #endif

--- a/server/NetdNativeService.cpp
+++ b/server/NetdNativeService.cpp
@@ -342,6 +342,22 @@ binder::Status NetdNativeService::bandwidthRemoveNiceApp(int32_t uid) {
     return statusFromErrcode(res);
 }
 
+binder::Status NetdNativeService::bandwidthAddRestrictAppOnInterface(const std::string& usecase,
+        const std::string& ifName, int32_t uid) {
+    NETD_LOCKING_RPC(gCtls->bandwidthCtrl.lock, PERM_NETWORK_STACK, PERM_MAINLINE_NETWORK_STACK);
+    std::vector<std::string> appStrUids = {std::to_string(abs(uid))};
+    int res = gCtls->bandwidthCtrl.addRestrictAppsOnInterface(usecase, ifName, appStrUids);
+    return statusFromErrcode(res);
+}
+
+binder::Status NetdNativeService::bandwidthRemoveRestrictAppOnInterface(const std::string& usecase,
+        const std::string& ifName, int32_t uid) {
+    NETD_LOCKING_RPC(gCtls->bandwidthCtrl.lock, PERM_NETWORK_STACK, PERM_MAINLINE_NETWORK_STACK);
+    std::vector<std::string> appStrUids = {std::to_string(abs(uid))};
+    int res = gCtls->bandwidthCtrl.removeRestrictAppsOnInterface(usecase, ifName, appStrUids);
+    return statusFromErrcode(res);
+}
+
 binder::Status NetdNativeService::networkCreatePhysical(int32_t netId, int32_t permission) {
     ENFORCE_NETWORK_STACK_PERMISSIONS();
     int ret = gCtls->netCtrl.createPhysicalNetwork(netId, convertPermission(permission));

--- a/server/NetdNativeService.h
+++ b/server/NetdNativeService.h
@@ -61,6 +61,12 @@ class NetdNativeService : public BinderService<NetdNativeService>, public BnNetd
     binder::Status bandwidthRemoveNaughtyApp(int32_t uid) override;
     binder::Status bandwidthAddNiceApp(int32_t uid) override;
     binder::Status bandwidthRemoveNiceApp(int32_t uid) override;
+    binder::Status bandwidthAddRestrictAppOnInterface(const std::string& usecase,
+                                                      const std::string& ifName,
+                                                      int32_t uid) override;
+    binder::Status bandwidthRemoveRestrictAppOnInterface(const std::string& usecase,
+                                                         const std::string& ifName,
+                                                         int32_t uid) override;
 
     // Network and routing commands.
     binder::Status networkCreatePhysical(int32_t netId, int32_t permission) override;

--- a/server/aidl_api/netd_aidl_interface/2/android/net/INetd.aidl
+++ b/server/aidl_api/netd_aidl_interface/2/android/net/INetd.aidl
@@ -111,6 +111,8 @@ interface INetd {
   void firewallRemoveUidInterfaceRules(in int[] uids);
   void trafficSwapActiveStatsMap();
   IBinder getOemNetd();
+  void bandwidthAddRestrictAppOnInterface(in @utf8InCpp String usecase, in @utf8InCpp String ifName, int uid);
+  void bandwidthRemoveRestrictAppOnInterface(in @utf8InCpp String usecase, in @utf8InCpp String ifName, int uid);
   const int IPV4 = 4;
   const int IPV6 = 6;
   const int CONF = 1;

--- a/server/binder/android/net/INetd.aidl
+++ b/server/binder/android/net/INetd.aidl
@@ -1309,4 +1309,27 @@ interface INetd {
      *                                  cause of the failure.
      */
      TetherStatsParcel tetherOffloadGetAndClearStats(int ifIndex);
+
+    * Add a network traffic restriction to/from an interface for a specific app
+    *
+    * @param usecase caller usecase
+    * @param ifName interface name
+    * @param uid uid of target app
+    * @throws ServiceSpecificException in case of failure, with an error code indicating the
+    *         cause of the failure.
+    */
+    void bandwidthAddRestrictAppOnInterface(in @utf8InCpp String usecase,
+            in @utf8InCpp String ifName, int uid);
+
+   /**
+    * Remove a network traffic restriction to/from an interface for a specific app
+    *
+    * @param usecase caller usecase
+    * @param ifName interface name
+    * @param uid uid of target app
+    * @throws ServiceSpecificException in case of failure, with an error code indicating the
+    *         cause of the failure.
+    */
+    void bandwidthRemoveRestrictAppOnInterface(in @utf8InCpp String usecase,
+            in @utf8InCpp String ifName, int uid);
 }


### PR DESCRIPTION
Author: Uldiniad <olivercscott@gmail.com>
Date:   Thu Mar 1 08:54:00 2018 -0500

    [3/3] NetD : Allow passing in interface names for wifi/data app restriction

    CYAN-3976
    CRACKLING-834

    This is a simplification and adpatation for oreo of:
    https://review.lineageos.org/#/c/LineageOS/android_system_netd/+/144246/
    by wangjing <wangjing@codeaurora.org>

    Change-Id: I085434d70dfe00e9c27b821661fff5076d57e930

Change-Id: Ie52b9c041a2415abce03b9092972113f890a13e0

----

Author: Uldiniad <olivercscott@gmail.com>
Date:   Tue Oct 30 23:59:08 2018 +0000

    NetD : Allow passing in interface names for vpn app restriction

    Change-Id: I7cb0c895db60dcf6b4fe59732ec6c0ec3c212a04

----

Author: Sam Mortimer <sam@mortimer.me.uk>
Date:   Thu Aug 29 16:48:55 2019 -0700

    netd: Consolidate restrict apps methods

    * These are lineage additions (that originated
      from caf).

    * addRestrictAppsOnData, addRestrictAppsOnVpn and
      addRestrictAppsOnWlan all do a similar thing
      (fw/b passes different interface arguments).

    * Consolidate into addRestrictAppsOnInterface
      (and removeRestrictAppsOnInterface)

    * Requires corresponding fw/b services change.

    Change-Id: Ic780e943583e616c137c42aa4a72f7af63d02dce

Change-Id: Ieaa34e922dcbe3bd7b293781b0f56e0eb02b7606